### PR TITLE
GCT packages are now available in EPEL stable

### DIFF
--- a/index.md
+++ b/index.md
@@ -25,9 +25,22 @@ With this effort, we aim to:
 News
 ----
 
+### 2018-10-16 ###
+
+Grid Community Toolkit packages are now available in EPEL stable and Fedora 28 stable.
+
+- EPEL 6:  
+<https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2018-d19f4f231e>
+
+- EPEL 7:  
+<https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2018-8aebaba2a9>
+
+- Fedora 28:
+<https://bodhi.fedoraproject.org/updates/FEDORA-2018-b36a6d2d0d>
+
 ### 2018-09-24 ###
 
-Package updates based on the Grid Community Toolkit are now available in Fedora updates testing, EPEL testing and Debian unstable.
+Package updates based on the Grid Community Toolkit are now available in EPEL testing, Fedora updates testing and Debian unstable and testing.
 
 - EPEL 6:  
 <https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2018-d19f4f231e>
@@ -42,4 +55,4 @@ Package updates based on the Grid Community Toolkit are now available in Fedora 
 <https://bodhi.fedoraproject.org/updates/FEDORA-2018-f9acba9316>
 
 - Debian:  
-<https://packages.debian.org/search?suite=buster&searchon=all&keywords=GridCF>
+<https://qa.debian.org/developer.php?login=mattias.ellert@physics.uu.se>


### PR DESCRIPTION
As per [1] and news for EPEL6 ([2]) and EPEL7 ([3]) I'd like to create a new news entry to reflect that change of availability of GCT packages in the "stable" repositories.

[1]: https://mailman.egi.eu/pipermail/gt-eos/2018-October/000231.html
[2]: https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2018-d19f4f231e
[3]: https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2018-8aebaba2a9

Actually the EPEL URLs used in the news entry for 2018-10-16 don't differ from the ones for 2018-09-24, so we could have actually just updated the 2018-09-24 news entry. But I'd like to keep the older news entry for historical reasons, so I created a new news entry.

****

Fedora is currently excluded because for Fedora 29 GCT packages are still in "testing" only, not sure why though (see [4]). @ellert: Is this an error?

[4]: https://bodhi.fedoraproject.org/updates/FEDORA-2018-f9acba9316

We could of course wait a few days until GCT packages reach Fedora 29 updates stable and then include that change into this PR.

****

This PR also includes two changes for the news entry for 2018-09-24:
* Reorder description, as the list starts with EPEL
* Use "original" URL for Debian information as the other one doesn't work sometimes
