### PR TITLE
Maarten replaces Oliver as the CERN rep.

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -68,11 +68,11 @@ In addition to releases, activities that require a vote include:
 [PMC members](#pmc-members)
 ---------------------------
 
-As of 13 November 2017, these are the current members for the PMC:
+As of 12 March 2021, these are the current members for the PMC:
 
 - Jim Basney
 - Mattias Ellert
-- Oliver Keeble
+- Maarten Litmaath
 - Brian Lin
 - Mischa Salle
 - Frank Scheiner

--- a/governance.md
+++ b/governance.md
@@ -72,8 +72,8 @@ As of 12 March 2021, these are the current members for the PMC:
 
 - Jim Basney
 - Mattias Ellert
-- Maarten Litmaath
 - Brian Lin
+- Maarten Litmaath
 - Mischa Salle
 - Frank Scheiner
 - Matthew Viljoen


### PR DESCRIPTION
Change approved 12th March by PMC.